### PR TITLE
[enhancement] Add support to set DOM node for dropdown popup via 'morePopupContainer' prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ React.render(
 | editable | { onEdit(type: 'add' | 'remove', info: { key, event }), showAdd: boolean, removeIcon: ReactNode, addIcon: ReactNode } | - | config tab editable |
 | locale | { dropdownAriaLabel: string, removeAriaLabel: string, addAriaLabel: string } | - | Accessibility locale help text |
 | moreIcon | ReactNode | - | collapse icon |
+| morePopupContainer | (menuDOMNode) => HTMLElement | () => document.body | DOM node container for 'more' dropdown popup |
 | tabBarGutter | number | 0 | config tab bar gutter |
 | tabBarPosition | `'left' | 'right' | 'top' | 'bottom'` | `'top'` | tab nav 's position |
 | tabBarStyle | style | - | tab nav style |

--- a/examples/popup-container.tsx
+++ b/examples/popup-container.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import Tabs, { TabPane } from '../src';
+import '../assets/index.less';
+
+const tabs: React.ReactElement[] = [];
+
+for (let i = 0; i < 50; i += 1) {
+  tabs.push(
+    <TabPane key={i} tab={`Tab ${i}`}>
+      Content of {i}
+    </TabPane>,
+  );
+}
+
+const getPopupRoot = (POPUP_ROOT_ID = 'awesome-tabs-popup', docRoot = document.body) => {
+  let popupRoot = document.getElementById(POPUP_ROOT_ID);
+
+  if (popupRoot) { return popupRoot; }
+
+  // no root element, let's create one...
+  popupRoot = document.createElement('div');
+  popupRoot.id = POPUP_ROOT_ID;
+
+  (docRoot as HTMLElement).append(popupRoot);
+
+  return popupRoot;
+};
+
+export default () => {
+  return (
+    <div style={{ maxWidth: 550 }}>
+      <Tabs
+        className="awesome-tabs"
+        defaultActiveKey="8"
+        moreIcon="..."
+        morePopupContainer={() => getPopupRoot()}
+      >
+        {tabs}
+      </Tabs>
+    </div>
+  );
+};

--- a/src/TabNavList/OperationNode.tsx
+++ b/src/TabNavList/OperationNode.tsx
@@ -19,6 +19,7 @@ export interface OperationNodeProps {
   mobile: boolean;
   moreIcon?: React.ReactNode;
   moreTransitionName?: string;
+  morePopupContainer?: (node: HTMLElement) => HTMLElement;
   editable?: EditableConfig;
   locale?: TabsLocale;
   onTabClick: (key: React.Key, e: React.MouseEvent | React.KeyboardEvent) => void;
@@ -33,6 +34,7 @@ function OperationNode(
     mobile,
     moreIcon = 'More',
     moreTransitionName,
+    morePopupContainer,
     style,
     className,
     editable,
@@ -158,6 +160,7 @@ function OperationNode(
       overlay={menu}
       trigger={['hover']}
       visible={open}
+      getPopupContainer={morePopupContainer}
       transitionName={moreTransitionName}
       onVisibleChange={setOpen}
       overlayClassName={overlayClassName}

--- a/src/TabNavList/index.tsx
+++ b/src/TabNavList/index.tsx
@@ -37,6 +37,7 @@ export interface TabNavListProps {
   editable?: EditableConfig;
   moreIcon?: React.ReactNode;
   moreTransitionName?: string;
+  morePopupContainer?: (node: HTMLElement) => HTMLElement;
   mobile: boolean;
   tabBarGutter?: number;
   renderTabBar?: RenderTabBar;

--- a/src/Tabs.tsx
+++ b/src/Tabs.tsx
@@ -62,6 +62,8 @@ export interface TabsProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'o
 
   // Icons
   moreIcon?: React.ReactNode;
+  morePopupContainer?: (node: HTMLElement) => HTMLElement;
+
   /** @private Internal usage. Not promise will rename in future */
   moreTransitionName?: string;
 }
@@ -103,6 +105,7 @@ function Tabs(
     tabBarExtraContent,
     locale,
     moreIcon,
+    morePopupContainer,
     moreTransitionName,
     destroyInactiveTabPane,
     renderTabBar,
@@ -205,6 +208,7 @@ function Tabs(
     locale,
     moreIcon,
     moreTransitionName,
+    morePopupContainer,
     tabBarGutter,
     onTabClick: onInternalTabClick,
     onTabScroll,


### PR DESCRIPTION
Issues solved:

- [x] [Tabs] Add support to change the DOM node used when rendering the more dropdown menu via optional `morePopupContainer` fn prop
- [x] [examples] Add `morePopupContainer` prop example
- [x] [docs] Add `morePopupContainer` prop description to readme